### PR TITLE
Fixed LocalEventProcessorsAdminServiceTest.testGetByComponent

### DIFF
--- a/axonserver/src/test/java/io/axoniq/axonserver/admin/eventprocessor/requestprocessor/LocalEventProcessorsAdminServiceTest.java
+++ b/axonserver/src/test/java/io/axoniq/axonserver/admin/eventprocessor/requestprocessor/LocalEventProcessorsAdminServiceTest.java
@@ -41,7 +41,7 @@ import reactor.test.StepVerifier;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
-
+import java.util.Arrays;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.any;
@@ -430,9 +430,12 @@ public class LocalEventProcessorsAdminServiceTest {
                                           .flatMap(eventProcessor -> Flux.fromIterable(eventProcessor.instances()))
                                           .map(EventProcessorInstance::clientId);
 
-        StepVerifier.create(clients)
-                    .expectNext("Client-A", "Client-B", "Client-E")
-                    .verifyComplete();
+        StepVerifier.create(clients.collectList())
+                .consumeNextWith(sortedClients -> {
+                    Collections.sort(sortedClients);
+                    Assertions.assertEquals(Arrays.asList("Client-A", "Client-B", "Client-E"), sortedClients);
+                })
+                .verifyComplete();
     }
 
     @Test


### PR DESCRIPTION
This pull request addresses the flakiness in the `LocalEventProcessorsAdminServiceTest.testGetByComponent` test by resolving the non-deterministic behavior identified using the NonDex tool. The root cause of the flakiness was the non-deterministic order of elements in `clients` Flux. The test can be found [here](https://github.com/AxonIQ/axon-server-se/blob/axonserver-se-4.6.x/axonserver/src/test/java/io/axoniq/axonserver/admin/eventprocessor/requestprocessor/LocalEventProcessorsAdminServiceTest.java).

- How was the non-deterministic behavior identified in the test?
The non-deterministic behavior in the test was identified by using an open-source research tool named [NonDex](https://github.com/TestingResearchIllinois/NonDex) which is responsible for finding and diagnosing non-deterministic runtime exceptions in Java programs.

- Why does the test fail?
The test fails because the actual order of elements emitted by the clients Flux does not match the expected order specified in the expectNext assertion. This assertion expects the elements to be emitted in the order "Client-A", "Client-B", "Client-E." However, the actual order of elements emitted might not be guaranteed.

- How I fixed the test?
I fixed the test by using `clients.collectList()` to collect all emitted elements into a list. After collecting the elements into a list, `Collections.sort(sortedClients)` is used to sort the list. Sorting the list is important because the test is no longer enforcing a specific order of elements; instead, it is interested in their presence. The verification step uses `consumeNextWith`, which allows you to consume the collected list (`sortedClients`) and perform assertions on it. In this case, it ensures that the sorted list of clients matches the expected list. `Assertions.assertEquals(Arrays.asList("Client-A", "Client-B", "Client-E"), sortedClients)` checks that the sorted list contains exactly the expected elements, irrespective of their order.

- Output from NonDex:
```
[INFO] Running io.axoniq.axonserver.admin.eventprocessor.requestprocessor.LocalEventProcessorsAdminServiceTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.997 s <<< FAILURE! - in io.axoniq.axonserver.admin.eventprocessor.requestprocessor.LocalEventProcessorsAdminServiceTest
[ERROR] testGetByComponent  Time elapsed: 0.628 s  <<< FAILURE!
java.lang.AssertionError: expectation "expectNext(Client-A)" failed (expected value: Client-A; actual value: Client-E)
	at io.axoniq.axonserver.admin.eventprocessor.requestprocessor.LocalEventProcessorsAdminServiceTest.testGetByComponent(LocalEventProcessorsAdminServiceTest.java:436)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   LocalEventProcessorsAdminServiceTest.testGetByComponent:436 expectation "expectNext(Client-A)" failed (expected value: Client-A; actual value: Client-E)
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
INFO: Surefire failed when running tests for vuAhCB8GKSHhZEIc0h0gvE+jEYAcSvbA34238fnKQM=
INFO: Adding excluded groups to newly created one
INFO: Creating new argline for Surefire
CONFIG: nondexFilter=.*
nondexMode=FULL
nondexSeed=1181842
nondexStart=0
nondexEnd=9223372036854775807
nondexPrintstack=false
nondexDir=/home/shetty5/project/newtests/axon-server-se/axonserver/.nondex
nondexJarDir=/home/shetty5/project/newtests/axon-server-se/axonserver/.nondex
nondexExecid=+Wxi0wkJBISX8nJdRxZlke7eciMzaodZvmb9lgEPyLI=
nondexLogging=CONFIG
```

You can run the following command to run the test using the NonDex tool:

```
mvn -pl axonserver edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=io.axoniq.axonserver.admin.eventprocessor.requestprocessor.LocalEventProcessorsAdminServiceTest#testGetByComponent -DnondexRuns=10
```

<br>
Test Environment:

```
java version 11.0.20.1
Apache Maven 3.6.3
```

Let me know if this fix is acceptable

Thank you!